### PR TITLE
ENH: Use mojimoji for full-half width conversion

### DIFF
--- a/doc/source/jpstrings.rst
+++ b/doc/source/jpstrings.rst
@@ -48,56 +48,26 @@ Unicode 正規化
 全角/半角変換
 -------------
 
-``Series.str.z2h`` で値を 全角文字から半角文字へ変換、 ``Series.str.h2z`` で値を 半角文字から全角文字へ変換できます。
+.. note:: この機能を利用するためには `mojimoji` のインストールが必要です。
+
+``Series.str.zen_to_han`` で値を 全角文字から半角文字へ変換、 ``Series.str.han_to_zen`` で値を 半角文字から全角文字へ変換できます。利用できるオプションなど、詳細は `mojimoji` のドキュメントを参照してください。
+
+https://github.com/studio-ousia/mojimoji
 
 .. code-block:: python
 
    >>> s = pd.Series([u'ｱｲｳｴｵ', u'ABC01', u'DE345'])
-   >>> z = s.str.h2z()
+   >>> z = s.str.han_to_zen()
    >>> z
    0    アイウエオ
    1    ＡＢＣ０１
    2    ＤＥ３４５
    dtype: object
 
-   >>> z.str.z2h()
+   >>> z.str.zen_to_han()
    0    ｱｲｳｴｵ
    1    ABC01
    2    DE345
    dtype: object
 
-
-変換の対象とする文字のグループはキーワードオプションで変更できます。それぞれのキーワードについて対象となる文字列は以下の通りです。デフォルトでは全て ``True`` で、全ての文字が変換されます。変換したくないグループがある場合は 対応するキーワードに ``False`` を指定してください。
-
-**補足** ``kana`` には日本語の記号 (句読点) も含まれることに注意してください。
-
-- ``kana``: ``ァアィイゥウェエォオカガキギクグケゲコゴサザシジスズセゼソゾタダチヂッツヅテデトドナニヌネノ
-  ハバパヒビピフブプヘベペホボポマミムメモャヤュユョヨラリルレロワヲンヴー・「」。、``
-- ``alpha``: ``ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz``
-- ``digit``: ``0123456789``
-- ``symbol``: ``!"#$%&'()*+,"-./:;<=>?@[\]^_`~{|}``
-
-.. code-block:: python
-
-    >>> s = pd.Series([u'ｱｲｳｴｵ', u'ABC01', u'DE345'])
-
-    # アルファベットは全角にしない
-    >>> s.str.h2z(alpha=False)
-    0    アイウエオ
-    1    ABC０１
-    2    DE３４５
-    dtype: object
-
-    # カナ、アルファベットは全角にしない
-    >>> s.str.h2z(kana=False, alpha=False, digit=True)
-    0    ｱｲｳｴｵ
-    1    ABC０１
-    2    DE３４５
-    dtype: object
-
-    # カナ、アルファベット、数値は全角にしない = 記号以外は半角のまま
-    >>> s.str.h2z(kana=False, alpha=False, digit=False)
-    0    ｱｲｳｴｵ
-    1    ABC01
-    2    DE345
-    dtype: object
+.. deprecated:: ``Series.str.z2h``, ``Series.str.h2z`` は deprecate され、将来のバージョンで削除されます。また、一部記号の扱いが ``mojimoji`` では異なります。

--- a/japandas/core/strings.py
+++ b/japandas/core/strings.py
@@ -4,9 +4,11 @@
 from __future__ import unicode_literals
 
 from unicodedata import normalize
+import warnings
 
+import numpy as np
 import pandas as pd
-from pandas.compat import PY3, iteritems, u_safe, reduce
+from pandas.compat import PY3, iteritems, u_safe, reduce, string_types
 import pandas.core.common as com
 
 import pandas.core.strings as strings
@@ -82,6 +84,7 @@ def _z2h_sm(text):
 
 
 def str_z2h(self, kana=True, alpha=True, digit=True, symbol=True):
+    warnings.warn("str.z2h is deprecated. Use str.zen_to_han instead", FutureWarning)
     mapper = dict()
     if kana:
         mapper.update(_Z2H_KANA)
@@ -106,6 +109,7 @@ def str_z2h(self, kana=True, alpha=True, digit=True, symbol=True):
 
 
 def str_h2z(self, kana=True, alpha=True, digit=True, symbol=True):
+    warnings.warn("str.h2z is deprecated. Use str.han_to_zen instead", FutureWarning)
     mapper = dict()
     if kana:
         mapper.update(_H2Z_KANA)
@@ -129,6 +133,36 @@ def str_h2z(self, kana=True, alpha=True, digit=True, symbol=True):
     return self._wrap_result(strings._na_map(f, self.series))
 
 
+def str_zen_to_han(self, ascii=True, digit=True, kana=True):
+    try:
+        import mojimoji
+
+        def f(x):
+            if PY3:
+                return mojimoji.zen_to_han(x, ascii=ascii, digit=digit, kana=kana)
+            else:
+                return mojimoji.zen_to_han(u_safe(x), ascii=ascii, digit=digit, kana=kana)
+
+        return self._wrap_result(strings._na_map(f, self.series))
+    except ImportError:
+        raise ImportError('str.zen_to_hanを利用するためには mojimoji をインストールしてください')
+
+
+def str_han_to_zen(self, ascii=True, digit=True, kana=True):
+    try:
+        import mojimoji
+
+        def f(x):
+            if PY3:
+                return mojimoji.han_to_zen(x, ascii=ascii, digit=digit, kana=kana)
+            else:
+                return mojimoji.han_to_zen(u_safe(x), ascii=ascii, digit=digit, kana=kana)
+
+        return self._wrap_result(strings._na_map(f, self.series))
+    except ImportError:
+        raise ImportError('str.han_to_zenを利用するためには mojimoji をインストールしてください')
+
+
 def str_normalize(self, form='NFKC'):
     if PY3:
         f = lambda x: normalize(form, x)
@@ -141,6 +175,16 @@ def str_normalize(self, form='NFKC'):
 if not hasattr(strings.StringMethods, 'normalize'):
     strings.StringMethods.normalize = str_normalize
 
+
+if not hasattr(strings.StringMethods, 'zen_to_han'):
+    strings.StringMethods.zen_to_han = str_zen_to_han
+
+
+if not hasattr(strings.StringMethods, 'han_to_zen'):
+    strings.StringMethods.han_to_zen = str_han_to_zen
+
+
+# deprecated
 
 if not hasattr(strings.StringMethods, 'z2h'):
     strings.StringMethods.z2h = str_z2h

--- a/japandas/core/tests/test_strings.py
+++ b/japandas/core/tests/test_strings.py
@@ -5,6 +5,7 @@
 
 import datetime
 
+import numpy as np
 import pandas as pd
 import pandas.compat as compat
 import pandas.util.testing as tm
@@ -13,6 +14,174 @@ import japandas as jpd
 
 
 class TestStrings(tm.TestCase):
+
+    def setUp(self):
+        self.zhiragana_s = pd.Series([u'ぁあぃいぅうぇえぉお',
+                                      u'かがきぎくぐけげこご',
+                                      u'さざしじすずせぜそぞ',
+                                      u'ただちぢっつづてでとど',
+                                      u'なにぬねの',
+                                      u'はばぱひびぴふぶぷへべぺほぼぽ',
+                                      u'まみむめもゃやゅゆょよ',
+                                      u'らりるれろわをんゎゐゑゕゖゔ'])
+
+        self.zkatakana_s = pd.Series([u'ァアィイゥウェエォオ',
+                                      u'カガキギクグケゲコゴ',
+                                      u'サザシジスズセゼソゾ',
+                                      u'タダチヂッツヅテデトド',
+                                      u'ナニヌネノ',
+                                      u'ハバパヒビピフブプヘベペホボポ',
+                                      u'マミムメモャヤュユョヨ',
+                                      u'ラリルレロワヲンヮヰヱヵヶヴ',
+                                      u'ー・「」。、'])
+
+        self.hkatakana_s = pd.Series([u'ｧｱｨｲｩｳｪｴｫｵ',
+                                      u'ｶｶﾞｷｷﾞｸｸﾞｹｹﾞｺｺﾞ',
+                                      u'ｻｻﾞｼｼﾞｽｽﾞｾｾﾞｿｿﾞ',
+                                      u'ﾀﾀﾞﾁﾁﾞｯﾂﾂﾞﾃﾃﾞﾄﾄﾞ',
+                                      u'ﾅﾆﾇﾈﾉ',
+                                      u'ﾊﾊﾞﾊﾟﾋﾋﾞﾋﾟﾌﾌﾞﾌﾟﾍﾍﾞﾍﾟﾎﾎﾞﾎﾟ',
+                                      u'ﾏﾐﾑﾒﾓｬﾔｭﾕｮﾖ',
+                                      u'ﾗﾘﾙﾚﾛﾜｦﾝヮヰヱヵヶｳﾞ',
+                                      u'ｰ･｢｣｡､'])
+
+        self.zalpha_s = pd.Series([u'ＡＢＣＤＥＦＧＨ',
+                                   u'ＩＪＫＬＭＮＯＰ',
+                                   u'ＱＲＳＴＵＶＷＸＹＺ',
+                                   u'ａｂｃｄｅｆｇｈ',
+                                   u'ｉｊｋｌｍｎｏｐ',
+                                   u'ｑｒｓｔｕｖｗｘｙｚ'])
+        self.halpha_s = pd.Series(['ABCDEFGH',
+                                   'IJKLMNOP',
+                                   'QRSTUVWXYZ',
+                                   'abcdefgh',
+                                   'ijklmnop',
+                                   'qrstuvwxyz'])
+
+        self.zdigit_s = pd.Series([u'０１２３４', u'５６７８９'])
+        self.hdigit_s = pd.Series(['01234', '56789'])
+
+    def test_zen_to_han(self):
+        s = pd.Series([u'ａａａ', 'bbb', u'アアア', u'１', u'＊'])
+        result = s.str.zen_to_han()
+        expected = pd.Series(['aaa', 'bbb', u'ｱｱｱ', '1', '*'])
+        tm.assert_series_equal(result, expected)
+
+        # full-width kana to half-width kana
+        result = self.zkatakana_s.str.zen_to_han(kana=True, ascii=False, digit=False)
+        tm.assert_series_equal(result, self.hkatakana_s)
+        result = self.zkatakana_s.str.zen_to_han(kana=False, ascii=True, digit=False)
+        tm.assert_series_equal(result, self.zkatakana_s)
+        result = self.zkatakana_s.str.zen_to_han(kana=False, ascii=False, digit=True)
+        tm.assert_series_equal(result, self.zkatakana_s)
+
+        # full-width kana to half-width alpha
+        result = self.zalpha_s.str.zen_to_han(kana=True, ascii=False, digit=False)
+        tm.assert_series_equal(result, self.zalpha_s)
+        result = self.zalpha_s.str.zen_to_han(kana=False, ascii=True, digit=False)
+        tm.assert_series_equal(result, self.halpha_s)
+        result = self.zalpha_s.str.zen_to_han(kana=False, ascii=False, digit=True)
+        tm.assert_series_equal(result, self.zalpha_s)
+
+        # full-width kana to half-width digit
+        result = self.zdigit_s.str.zen_to_han(kana=True, ascii=False, digit=False)
+        tm.assert_series_equal(result, self.zdigit_s)
+        result = self.zdigit_s.str.zen_to_han(kana=False, ascii=True, digit=False)
+        tm.assert_series_equal(result, self.zdigit_s)
+        result = self.zdigit_s.str.zen_to_han(kana=False, ascii=False, digit=True)
+        tm.assert_series_equal(result, self.hdigit_s)
+
+        # half-width to half-width
+        result = self.hkatakana_s.str.zen_to_han()
+        tm.assert_series_equal(result, self.hkatakana_s)
+        result = self.halpha_s.str.zen_to_han()
+        tm.assert_series_equal(result, self.halpha_s)
+        result = self.hdigit_s.str.zen_to_han()
+        tm.assert_series_equal(result, self.hdigit_s)
+
+    def test_han_to_zen(self):
+        s = pd.Series(['aaa', 'bbb', u'ｱｱｱ', u'１', '*'])
+        result = s.str.han_to_zen()
+        expected = pd.Series([u'ａａａ', u'ｂｂｂ', u'アアア', u'１', u'＊'])
+        tm.assert_series_equal(result, expected)
+
+        # half-width kana to full-width kana
+        result = self.hkatakana_s.str.han_to_zen(kana=True, ascii=False, digit=False)
+        tm.assert_series_equal(result, self.zkatakana_s)
+        result = self.hkatakana_s.str.han_to_zen(kana=False, ascii=True, digit=False)
+        tm.assert_series_equal(result, self.hkatakana_s)
+        result = self.hkatakana_s.str.han_to_zen(kana=False, ascii=False, digit=True)
+        tm.assert_series_equal(result, self.hkatakana_s)
+
+        # half-width kana to full-width alpha
+        result = self.halpha_s.str.han_to_zen(kana=True, ascii=False, digit=False)
+        tm.assert_series_equal(result, self.halpha_s)
+        result = self.halpha_s.str.han_to_zen(kana=False, ascii=True, digit=False)
+        tm.assert_series_equal(result, self.zalpha_s)
+        result = self.halpha_s.str.han_to_zen(kana=False, ascii=False, digit=True)
+        tm.assert_series_equal(result, self.halpha_s)
+
+        # half-width kana to full-width digit
+        result = self.hdigit_s.str.han_to_zen(kana=True, ascii=False, digit=False)
+        tm.assert_series_equal(result, self.hdigit_s)
+        result = self.hdigit_s.str.han_to_zen(kana=False, ascii=True, digit=False)
+        tm.assert_series_equal(result, self.hdigit_s)
+        result = self.hdigit_s.str.han_to_zen(kana=False, ascii=False, digit=True)
+        tm.assert_series_equal(result, self.zdigit_s)
+
+        # full-width to full-width
+        result = self.zkatakana_s.str.han_to_zen()
+        tm.assert_series_equal(result, self.zkatakana_s)
+        result = self.zalpha_s.str.han_to_zen()
+        tm.assert_series_equal(result, self.zalpha_s)
+        result = self.zdigit_s.str.han_to_zen()
+        tm.assert_series_equal(result, self.zdigit_s)
+        result = self.zkatakana_s.str.han_to_zen()
+        tm.assert_series_equal(result, self.zkatakana_s)
+
+    def test_zen_to_han_obj_deprecated(self):
+        s = pd.Series(['aaa', None, u'アアア', u'あああ', u'１', 3])
+        result = s.str.zen_to_han()
+        expected = pd.Series(['aaa', None, u'ｱｱｱ', u'あああ', '1', None])
+        tm.assert_series_equal(result, expected)
+
+        empty_str = pd.Series(dtype=str)
+        tm.assert_series_equal(empty_str.str.zen_to_han(), empty_str)
+
+    def test_han_to_zen_obj(self):
+        s = pd.Series(['aaa', None, u'ｱｱｱ', u'あああ', u'１', 3])
+        result = s.str.han_to_zen()
+        expected = pd.Series([u'ａａａ', None, u'アアア', u'あああ', u'１', None])
+        tm.assert_series_equal(result, expected)
+
+        empty_str = pd.Series(dtype=str)
+        tm.assert_series_equal(empty_str.str.han_to_zen(), empty_str)
+
+    def test_normalize(self):
+        s = pd.Series([u'ａａａ', 'bbb', u'ｱｱｱ', u'１', u'＊'])
+        result = s.str.normalize()
+        expected= pd.Series(['aaa', 'bbb', u'アアア', '1', '*'])
+        tm.assert_series_equal(result, expected)
+
+        s = pd.Series([u'ａａａ', None, 'bbb', u'ｱｱｱ', u'１', 5, u'＊'])
+        result = s.str.normalize()
+        expected= pd.Series(['aaa', None, 'bbb', u'アアア', '1', None, '*'])
+        tm.assert_series_equal(result, expected)
+
+        empty_str = pd.Series(dtype=str)
+        tm.assert_series_equal(empty_str.str.normalize(), empty_str)
+
+    def test_normalize_format(self):
+        import unicodedata
+        values = [u'ｱｲｳｴｵ', u'ｶｷｸｹｺ', u'ｶﾞｷﾞｸﾞｹﾞｺﾞ', u'ＡＢＣＤＥ']
+        for format in ['NFD', 'NFC', 'NFKD', 'NFKC']:
+            result = pd.Series(values).str.normalize(format).tolist()
+            expected = [unicodedata.normalize(format, v) for v in values]
+            tm.assert_equal(result, expected)
+
+
+
+class TestStringsDeprecated(tm.TestCase):
 
     def setUp(self):
         self.zhiragana_s = pd.Series([u'ぁあぃいぅうぇえぉお',
@@ -93,7 +262,7 @@ class TestStrings(tm.TestCase):
         tm.assert_equal(len(s._Z2H_SOUNDMARK), len(s._HSOUNDMARK))
         tm.assert_equal(len(s._H2Z_SOUNDMARK), len(s._HSOUNDMARK))
 
-    def test_z2h(self):
+    def test_z2h_deprecated(self):
         s = pd.Series([u'ａａａ', 'bbb', u'アアア', u'１', u'＊'])
         result = s.str.z2h()
         expected = pd.Series(['aaa', 'bbb', u'ｱｱｱ', '1', '*'])
@@ -149,7 +318,7 @@ class TestStrings(tm.TestCase):
         result = self.hsymbol_s.str.z2h()
         tm.assert_series_equal(result, self.hsymbol_s)
 
-    def test_h2z(self):
+    def test_h2z_deprecated(self):
         s = pd.Series(['aaa', 'bbb', u'ｱｱｱ', u'１', '*'])
         result = s.str.h2z()
         expected = pd.Series([u'ａａａ', u'ｂｂｂ', u'アアア', u'１', u'＊'])
@@ -205,7 +374,7 @@ class TestStrings(tm.TestCase):
         result = self.zkatakana_s.str.h2z()
         tm.assert_series_equal(result, self.zkatakana_s)
 
-    def test_z2h_obj(self):
+    def test_z2h_obj_deprecated(self):
         s = pd.Series(['aaa', None, u'アアア', u'あああ', u'１', 3])
         result = s.str.z2h()
         expected = pd.Series(['aaa', None, u'ｱｱｱ', u'あああ', '1', None])
@@ -214,7 +383,7 @@ class TestStrings(tm.TestCase):
         empty_str = pd.Series(dtype=str)
         tm.assert_series_equal(empty_str.str.h2z(), empty_str)
 
-    def test_h2z(self):
+    def test_h2z_obj_deprecated(self):
         s = pd.Series(['aaa', None, u'ｱｱｱ', u'あああ', u'１', 3])
         result = s.str.h2z()
         expected = pd.Series([u'ａａａ', None, u'アアア', u'あああ', u'１', None])
@@ -222,28 +391,6 @@ class TestStrings(tm.TestCase):
 
         empty_str = pd.Series(dtype=str)
         tm.assert_series_equal(empty_str.str.h2z(), empty_str)
-
-    def test_normalize(self):
-        s = pd.Series([u'ａａａ', 'bbb', u'ｱｱｱ', u'１', u'＊'])
-        result = s.str.normalize()
-        expected= pd.Series(['aaa', 'bbb', u'アアア', '1', '*'])
-        tm.assert_series_equal(result, expected)
-
-        s = pd.Series([u'ａａａ', None, 'bbb', u'ｱｱｱ', u'１', 5, u'＊'])
-        result = s.str.normalize()
-        expected= pd.Series(['aaa', None, 'bbb', u'アアア', '1', None, '*'])
-        tm.assert_series_equal(result, expected)
-
-        empty_str = pd.Series(dtype=str)
-        tm.assert_series_equal(empty_str.str.normalize(), empty_str)
-
-    def test_normalize_format(self):
-        import unicodedata
-        values = [u'ｱｲｳｴｵ', u'ｶｷｸｹｺ', u'ｶﾞｷﾞｸﾞｹﾞｺﾞ', u'ＡＢＣＤＥ']
-        for format in ['NFD', 'NFC', 'NFKD', 'NFKC']:
-            result = pd.Series(values).str.normalize(format).tolist()
-            expected = [unicodedata.normalize(format, v) for v in values]
-            tm.assert_equal(result, expected)
 
 
 if __name__ == '__main__':

--- a/japandas/version.py
+++ b/japandas/version.py
@@ -1,1 +1,1 @@
-version = '0.0.2'
+version = '0.0.3dev'

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -2,5 +2,6 @@ lxml
 html5lib
 beautifulsoup4
 pandas>=0.15.0
+mojimoji
 IPython>=2.3
 matplotlib>=1.4.0


### PR DESCRIPTION
```
import random
import string
import pandas as pd
import japandas as jpd

import time

s = pd.Series([random.choice(string.ascii_letters+string.digits)] * 100000)

# after the fix
t1 = time.clock()
z = s.str.han_to_zen()
s = s.str.zen_to_han()
time.clock() - t1
# 1.042687

# current impl
t2 = time.clock()
z = s.str.h2z()
s = s.str.z2h()
time.clock() - t2
# 2.788254
```